### PR TITLE
Avoid crashing when 3DconnexionClient.framework is not installed

### DIFF
--- a/Planito.xcodeproj/project.pbxproj
+++ b/Planito.xcodeproj/project.pbxproj
@@ -1516,6 +1516,10 @@
 				GCC_PREFIX_HEADER = "Planito/Planito-Prefix.pch";
 				INFOPLIST_FILE = "Planito/Planito-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					3DconnexionClient,
+				);
 				PLANITO_DATASOURCE = "http://ds.planitoapp.com/_datasource-{LANG}.xml.gz";
 				PLIST_FILE_OUTPUT_FORMAT = binary;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1559,6 +1563,10 @@
 				GCC_PREFIX_HEADER = "Planito/Planito-Prefix.pch";
 				INFOPLIST_FILE = "Planito/Planito-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					3DconnexionClient,
+				);
 				PLANITO_DATASOURCE = "http://ds.planitoapp.com/_datasource_demo-{LANG}.xml.gz";
 				PLIST_FILE_OUTPUT_FORMAT = binary;
 				PRODUCT_NAME = "$(TARGET_NAME) Demo";
@@ -1602,6 +1610,10 @@
 				GCC_PREFIX_HEADER = "Planito/Planito-Prefix.pch";
 				INFOPLIST_FILE = "Planito/Planito-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					3DconnexionClient,
+				);
 				PLANITO_DATASOURCE = "http://ds.planitoapp.com/_datasource-{LANG}.xml";
 				PLIST_FILE_OUTPUT_FORMAT = binary;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
For users who don’t have the 3DconnexionClient framework installed, the app would crash on launch with the following message:

``` md
dyld: Library not loaded: /Library/Frameworks/3DconnexionClient.framework/Versions/A/3DconnexionClient
  […]
  Reason: image not found
```

I feel this to be a possible cause for issue #1.

This PR adds the linker flag `-weak_framework 3DconnexionClient` which seems to fix the issue.
